### PR TITLE
Added license information to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,4 +19,11 @@
             <type>jar</type>
         </dependency>
     </dependencies>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://spdx.org/licenses/MIT.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 </project>


### PR DESCRIPTION
The pom.xml file has the option to specify the license information.
Having this information available in the pom file makes it easier for
people using the library to integrate this information with tools. For
example have a report listing all licenses of 3th party repositories,
having automated checks whether all used 3th party libs have a license
allowing them to be used, ... .